### PR TITLE
fix payment method not appearing on frontend

### DIFF
--- a/includes/class-wc-gateway-spectrocoin.php
+++ b/includes/class-wc-gateway-spectrocoin.php
@@ -245,7 +245,7 @@ class WC_Gateway_Spectrocoin extends WC_Payment_Gateway
 			return false;
 		}
 	
-		if ($this->spectrocoin_is_test_mode_enabled() && !current_user_can('manage_options')) {
+		if ($this->spectrocoin_is_test_mode_enabled() === 'yes' && !current_user_can('manage_options')) {
 			return false;
 		}
 


### PR DESCRIPTION
This fixes the "test mode" feature in the plugin options.

The test mode is supposed to show the payment method to admin when enabled. The problem was that was never showing the payment method to the final users, even if it was disabled.

Related to #14 